### PR TITLE
Fix broken link to AGILE reproducible paper guidelines

### DIFF
--- a/2020.md
+++ b/2020.md
@@ -28,7 +28,7 @@ Reproducibility, replicability, and transparency are widely recognised as crucia
 This half day workshop teaches participants concepts and best practicesfor reproducible research.
 The workshop prepares participants for the future of research publications by means of presenting the AGILE Reproducible Paper Guidelines in detail, demonstrating common tools for reproducible research, and discussing participants' questions and own experiences in the light of reproducibility.
 
-In the GIScience community, the AGILE conference is leading the endeavour towards higher reproducibility with establishing the [_AGILE Reproducible Paper Guidelines_](​https://doi.org/10.17605/OSF.IO/CB7Z8​) for the 2020 conference.
+In the GIScience community, the AGILE conference is leading the endeavour towards higher reproducibility with establishing the _[AGILE Reproducible Paper Guidelines](https://doi.org/10.17605/OSF.IO/CB7Z8)_ for the 2020 conference.
 The guidelines include detailed information about rationale, motivation and vision of reproducible publications at AGILE Conferences.
 They also link numerous resources for detailed and specific practices, e.g. for social media data, personal data, or workflows in specific programming languages.
 After the workshop, participants will have a good understanding of the rationale behind the guidelines and the different aspects of data, code, and environments that matter for reproducibility.


### PR DESCRIPTION
The link to the reproducibel paper guidelines was broken for me at the website. 
This hopefully fixes it.